### PR TITLE
Implement async daemon IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,296 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
+
+[[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+
+[[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "tokio"
+version = "1.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "udcn-cli"
 version = "0.1.0"
 dependencies = [
@@ -17,6 +307,8 @@ version = "0.1.0"
 name = "udcn-daemon"
 version = "0.1.0"
 dependencies = [
+ "lru",
+ "tokio",
  "udcn-common",
 ]
 
@@ -27,3 +319,103 @@ version = "0.1.0"
 [[package]]
 name = "udcn-quic"
 version = "0.1.0"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/docs/persistent-daemon.md
+++ b/docs/persistent-daemon.md
@@ -1,0 +1,18 @@
+# μDCN Persistent Daemon IPC
+
+The daemon listens on a Unix domain socket at `/tmp/udcn.sock` and accepts simple
+newline delimited commands. Each connection is handled independently. Commands
+and responses are UTF‑8 text.
+
+## Commands
+
+- `fib add <prefix> <face>` – Insert a forwarding entry mapping a name prefix to
+a face identifier. Returns `OK` on success.
+- `fib list` – List all FIB entries in the form `<prefix> -> <face>`.
+- `cs stats` – Return the current number of entries stored in the content
+  store.
+- `quit` – Close the connection.
+
+Unknown commands result in `UNKNOWN`.
+
+

--- a/udcn-daemon/Cargo.toml
+++ b/udcn-daemon/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 udcn-common = { path = "../udcn-common" }
+tokio = { version = "1", features = ["full"] }
+lru = "0.7"
 
 [[bin]]
 name = "udcn-daemon"

--- a/udcn-daemon/src/cs.rs
+++ b/udcn-daemon/src/cs.rs
@@ -1,0 +1,31 @@
+use lru::LruCache;
+use udcn_common::Data;
+
+/// Content Store implementing an LRU cache.
+pub struct ContentStore {
+    cache: LruCache<String, Data>,
+}
+
+impl ContentStore {
+    /// Create a new content store with the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        ContentStore {
+            cache: LruCache::new(capacity.try_into().unwrap_or(16)),
+        }
+    }
+
+    /// Insert a Data packet into the store.
+    pub fn insert(&mut self, data: Data) {
+        self.cache.put(data.name.clone(), data);
+    }
+
+    /// Retrieve a Data packet by name.
+    pub fn get(&mut self, name: &str) -> Option<&Data> {
+        self.cache.get(name)
+    }
+
+    /// Return current number of stored entries.
+    pub fn len(&self) -> usize {
+        self.cache.len()
+    }
+}

--- a/udcn-daemon/src/fib.rs
+++ b/udcn-daemon/src/fib.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+
+/// Forwarding Information Base with longest prefix match.
+#[derive(Default)]
+pub struct Fib {
+    entries: HashMap<String, String>, // prefix -> face identifier
+}
+
+impl Fib {
+    /// Add a prefix and next hop identifier.
+    pub fn add(&mut self, prefix: String, face: String) {
+        self.entries.insert(prefix, face);
+    }
+
+    /// Return the next hop that best matches the name.
+    pub fn lookup(&self, name: &str) -> Option<&String> {
+        let mut best: Option<&String> = None;
+        let mut best_len = 0usize;
+        for (prefix, face) in &self.entries {
+            if name.starts_with(prefix) && prefix.len() > best_len {
+                best = Some(face);
+                best_len = prefix.len();
+            }
+        }
+        best
+    }
+
+    pub fn list(&self) -> Vec<(String, String)> {
+        self.entries
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect()
+    }
+}

--- a/udcn-daemon/src/main.rs
+++ b/udcn-daemon/src/main.rs
@@ -1,5 +1,72 @@
-fn main() {
-    println!("udcn-daemon starting...");
-    // TODO: daemon logic with async runtime
-}
+mod cs;
+mod fib;
+mod pit;
 
+use cs::ContentStore;
+use fib::Fib;
+use pit::Pit;
+use std::sync::{Arc, Mutex};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixListener;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    println!("udcn-daemon starting...");
+    let _ = std::fs::remove_file("/tmp/udcn.sock");
+    let listener = UnixListener::bind("/tmp/udcn.sock")?;
+
+    let fib = Arc::new(Mutex::new(Fib::default()));
+    let _pit = Arc::new(Mutex::new(Pit::default()));
+    let cs = Arc::new(Mutex::new(ContentStore::new(16)));
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let fib = fib.clone();
+        let cs = cs.clone();
+        tokio::spawn(async move {
+            let (r, mut w) = stream.into_split();
+            let mut reader = BufReader::new(r);
+            let mut line = String::new();
+            while reader.read_line(&mut line).await.unwrap_or(0) > 0 {
+                let parts: Vec<String> = line
+                    .trim()
+                    .split_whitespace()
+                    .map(|s| s.to_string())
+                    .collect();
+                line.clear();
+                if parts.is_empty() {
+                    continue;
+                }
+                match parts[0].as_str() {
+                    "fib" => {
+                        if parts.get(1).map(|s| s.as_str()) == Some("add") {
+                            if let (Some(p), Some(f)) = (parts.get(2), parts.get(3)) {
+                                fib.lock().unwrap().add(p.clone(), f.clone());
+                                let _ = w.write_all(b"OK\n").await;
+                            } else {
+                                let _ = w.write_all(b"ERR\n").await;
+                            }
+                        } else if parts.get(1).map(|s| s.as_str()) == Some("list") {
+                            let entries = fib.lock().unwrap().list();
+                            for (p, f) in entries {
+                                let _ = w.write_all(format!("{} -> {}\n", p, f).as_bytes()).await;
+                            }
+                        }
+                    }
+                    "cs" => {
+                        if parts.get(1).map(|s| s.as_str()) == Some("stats") {
+                            let len = cs.lock().unwrap().len();
+                            let _ = w
+                                .write_all(format!("CS entries: {}\n", len).as_bytes())
+                                .await;
+                        }
+                    }
+                    "quit" => break,
+                    _ => {
+                        let _ = w.write_all(b"UNKNOWN\n").await;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/udcn-daemon/src/pit.rs
+++ b/udcn-daemon/src/pit.rs
@@ -1,0 +1,34 @@
+use std::collections::HashMap;
+use tokio::time::{Duration, Instant};
+
+/// Pending Interest Table entry expiration time.
+pub type Expiration = Instant;
+
+/// Pending Interest Table.
+#[derive(Default)]
+pub struct Pit {
+    entries: HashMap<String, Expiration>,
+}
+
+impl Pit {
+    /// Insert a name with a lifetime.
+    pub fn insert(&mut self, name: String, lifetime: Duration) {
+        self.entries.insert(name, Instant::now() + lifetime);
+    }
+
+    /// Remove an entry.
+    pub fn remove(&mut self, name: &str) {
+        self.entries.remove(name);
+    }
+
+    /// Check if a name exists.
+    pub fn contains(&self, name: &str) -> bool {
+        self.entries.contains_key(name)
+    }
+
+    /// Drop expired entries.
+    pub fn sweep(&mut self) {
+        let now = Instant::now();
+        self.entries.retain(|_, &mut exp| exp > now);
+    }
+}


### PR DESCRIPTION
## Summary
- rework `udcn-daemon` to run on Tokio and listen on `/tmp/udcn.sock`
- add simple FIB, PIT and CS data structures
- expose IPC commands via unix socket
- document the daemon protocol

## Testing
- `cargo fmt --all`
- `cargo check --workspace`
- `cargo build --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68604f41970c83279ff8859677abb4a0