### PR TITLE
Implement XDP pass program

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,12 @@ This repository contains a minimal work-in-progress implementation of micro Data
 - **udcn-common** – shared packet types and utilities.
 - **udcn-cli** – simple command line interface.
 - **udcn-daemon** – forwarder daemon (stub).
-- **udcn-ebpf** – XDP program placeholder.
+- **udcn-ebpf** – eBPF XDP program.
 - **udcn-quic** – QUIC transport abstraction.
 
 Additional folders include `docker/` for container files and `demo/` for example scenarios.
+
+For instructions on building the eBPF program and attaching it using Aya's `XdpManager`, see [`docs/ebpf_build.md`](docs/ebpf_build.md).
 
 All crates currently provide only minimal functionality but compile successfully with `cargo build --workspace`.
 

--- a/docs/ebpf_build.md
+++ b/docs/ebpf_build.md
@@ -1,0 +1,33 @@
+# Building and Attaching the eBPF Program
+
+The `udcn-ebpf` crate is a `no_std` XDP program. Building requires the
+nightly toolchain and the `bpfel-unknown-none` target.
+
+```bash
+rustup default nightly
+rustup target add bpfel-unknown-none
+```
+
+Build the program with:
+
+```bash
+cargo build -p udcn-ebpf --target=bpfel-unknown-none -Z build-std=core
+```
+
+The resulting object file can be loaded using `XdpManager` from the
+`aya` project:
+
+```rust
+use aya::Bpf;
+use aya::programs::Xdp;
+use aya::util::online_cpus;
+use aya::maps::ProgramData;
+
+let mut bpf = Bpf::load_file("target/bpfel-unknown-none/debug/udcn-ebpf")?;
+let program: &mut Xdp = bpf.program_mut("xdp_pass")?.try_into()?;
+program.load()?;
+program.attach("eth0", aya::programs::XdpFlags::default())?;
+```
+
+This attaches the XDP program to the interface `eth0` and simply passes
+all packets through.

--- a/udcn-ebpf/Cargo.toml
+++ b/udcn-ebpf/Cargo.toml
@@ -2,10 +2,13 @@
 name = "udcn-ebpf"
 version = "0.1.0"
 edition = "2021"
+build = "build.rs"
 
 [lib]
 path = "src/lib.rs"
 crate-type = ["staticlib"]
+test = false
+doctest = false
 
 
 [profile.dev]

--- a/udcn-ebpf/build.rs
+++ b/udcn-ebpf/build.rs
@@ -1,0 +1,14 @@
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").unwrap_or_default();
+    if target == "bpfel-unknown-none" {
+        // Preserve existing flags if any
+        let mut flags = env::var("RUSTFLAGS").unwrap_or_default();
+        if !flags.is_empty() {
+            flags.push(' ');
+        }
+        flags.push_str("-Z build-std=core");
+        println!("cargo:rustc-env=RUSTFLAGS={flags}");
+    }
+}

--- a/udcn-ebpf/src/lib.rs
+++ b/udcn-ebpf/src/lib.rs
@@ -1,13 +1,13 @@
 #![no_std]
 
-// Minimal eBPF program placeholder
+// Minimal XDP program that always passes packets.
 #[no_mangle]
-pub extern "C" fn xdp_prog() -> u32 {
-    0
+pub extern "C" fn xdp_pass(_ctx: *mut core::ffi::c_void) -> u32 {
+    const XDP_PASS: u32 = 2;
+    XDP_PASS
 }
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}
 }
-


### PR DESCRIPTION
## Summary
- add a minimal XDP program in `udcn-ebpf`
- compile BPF target with `-Z build-std=core` via build script
- disable the default test harness for the eBPF crate
- document how to build and attach the program with Aya
- update README

## Testing
- `cargo check --workspace`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_686050b0cf8083278b64630382943fa6