### PR TITLE
Add build instructions and Docker demo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,58 @@
 # μDCN in Rust
 
-This repository contains a minimal work-in-progress implementation of micro Data-Centric Networking (μDCN) written in Rust. The codebase is organized as a Cargo workspace with multiple crates:
+This repository contains a minimal implementation of micro Data-Centric Networking (μDCN) written in Rust. The project is organised as a Cargo workspace and consists of multiple crates.
+
+## Architecture Overview
 
 - **udcn-common** – shared packet types and utilities.
-- **udcn-cli** – simple command line interface.
-- **udcn-daemon** – forwarder daemon (stub).
-- **udcn-ebpf** – eBPF XDP program.
-- **udcn-quic** – QUIC transport abstraction.
+- **udcn-cli** – command line interface for interacting with the daemon.
+- **udcn-daemon** – async forwarder daemon providing a Unix socket API.
+- **udcn-ebpf** – XDP program compiled to eBPF and attached by the daemon.
+- **udcn-quic** – QUIC transport abstraction used by future components.
 
-Additional folders include `docker/` for container files and `demo/` for example scenarios.
+Additional folders:
 
-For instructions on building the eBPF program and attaching it using Aya's `XdpManager`, see [`docs/ebpf_build.md`](docs/ebpf_build.md).
+- **docker/** – container files and compose configuration.
+- **demo/** – simple scripts to run a multi node testbed.
 
-All crates currently provide only minimal functionality but compile successfully with `cargo build --workspace`.
+## Building
 
-## Usage Examples
+1. Install the Rust toolchain and `cargo`.
+2. Build all crates:
+   ```bash
+   cargo build --workspace
+   ```
+3. To build the eBPF program you need the nightly toolchain and the `bpfel-unknown-none` target:
+   ```bash
+   rustup default nightly
+   rustup target add bpfel-unknown-none
+   cargo build -p udcn-ebpf --target=bpfel-unknown-none -Z build-std=core
+   ```
+   See [`docs/ebpf_build.md`](docs/ebpf_build.md) for details.
+
+## CLI Examples
 
 Start the daemon:
-
 ```bash
 $ udcn start
 ```
 
 Express an interest:
-
 ```bash
 $ udcn interest /example/data
 ```
 
 Publish data (payload handling not yet implemented):
-
 ```bash
 $ udcn publish /example/data
 ```
 
 Add a FIB entry:
-
 ```bash
 $ udcn fib add /example
 ```
 
 Request statistics from the daemon:
-
 ```bash
 $ udcn stats
 ```

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,10 @@
+# Demo Scripts
+
+The `test_udcn.sh` script launches the Docker testbed defined in `docker/docker-compose.yml` and runs a few CLI commands inside the forwarder container. It is a quick way to check that the binaries work together.
+
+Run it from the repository root:
+```bash
+./demo/test_udcn.sh
+```
+The script builds the containers, adds a FIB entry and shows the forwarder's statistics before shutting everything down.
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,21 @@
+# Docker Setup
+
+The Docker files allow you to spin up a small testbed with a forwarder, client and server container. Each container uses the binaries built from this repository.
+
+1. Build the images and start the containers:
+   ```bash
+   docker compose -f docker/docker-compose.yml build
+   docker compose -f docker/docker-compose.yml up -d
+   ```
+2. Interact with the forwarder container using the `udcn` CLI, for example:
+   ```bash
+   docker compose -f docker/docker-compose.yml exec forwarder udcn fib add /demo
+   docker compose -f docker/docker-compose.yml exec forwarder udcn stats
+   ```
+3. Shut everything down once done:
+   ```bash
+   docker compose -f docker/docker-compose.yml down
+   ```
+
+See [`../docs/testbed.md`](../docs/testbed.md) for the expected output of the demo script located in `demo/test_udcn.sh`.
+

--- a/docs/sdsds.md
+++ b/docs/sdsds.md
@@ -1,1 +1,12 @@
+# Project Overview
+
+This document briefly describes the layout of the repository. Each crate in the workspace provides a specific piece of the μDCN prototype.
+
+- `udcn-cli` – command line tool that talks to the daemon over a Unix socket.
+- `udcn-daemon` – forwarder daemon attaching the eBPF program and maintaining forwarding state.
+- `udcn-ebpf` – minimal XDP program compiled with the nightly Rust toolchain.
+- `udcn-quic` – experimental QUIC transport wrapper.
+- `udcn-common` – shared data structures (Interest and Data packets).
+
+For Docker based experiments consult `docker/README.md` and `demo/README.md`.
 


### PR DESCRIPTION
## Summary
- document build steps and CLI usage in README
- add Docker and demo instructions
- replace placeholder docs file with project overview

## Testing
- `cargo build --workspace`


------
https://chatgpt.com/codex/tasks/task_e_68607c5e00fc8327823517771d23c5bc