### PR TITLE
Move profiles to workspace and setup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          components: rustfmt, clippy
+      - name: Format
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --workspace
+      - name: Build
+        run: cargo build --workspace --verbose
+      - name: Test
+        run: cargo test --workspace --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-name = "udcn-workspace"
 version = "0.1.0"
 
 

--- a/udcn-ebpf/Cargo.toml
+++ b/udcn-ebpf/Cargo.toml
@@ -11,9 +11,4 @@ test = false
 doctest = false
 
 
-[profile.dev]
-panic = "abort"
-
-[profile.release]
-panic = "abort"
 

--- a/udcn-ebpf/src/lib.rs
+++ b/udcn-ebpf/src/lib.rs
@@ -7,6 +7,7 @@ pub extern "C" fn xdp_pass(_ctx: *mut core::ffi::c_void) -> u32 {
     XDP_PASS
 }
 
+#[cfg(not(test))]
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     loop {}


### PR DESCRIPTION
## Summary
- consolidate `panic=abort` profiles in workspace Cargo.toml
- remove duplicated profile sections from eBPF crate
- guard eBPF panic handler during tests
- add GitHub Actions workflow running `fmt`, `clippy`, `build`, and `test`

## Testing
- `cargo clippy --workspace`
- `cargo build --workspace`
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68607dc7b3a88327bca594c78cfc0adb